### PR TITLE
fix: remove hardcoded mcp__claude-recall__ prefix from MCP tool names

### DIFF
--- a/src/cli/claude-recall-cli.ts
+++ b/src/cli/claude-recall-cli.ts
@@ -1255,7 +1255,7 @@ async function main() {
       lastSearchAt: Date.now(),
       searchQuery: 'test query',
       toolHistory: [
-        { tool: 'mcp__claude-recall__search', at: Date.now() }
+        { tool: 'search_memory', at: Date.now() }
       ]
     };
     fs.writeFileSync(stateFile, JSON.stringify(stateData, null, 2));
@@ -1497,7 +1497,7 @@ async function main() {
         console.log('\nTo use with Claude Code:');
         console.log('1. Ensure Claude Code is not running');
         console.log('2. Start Claude Code');
-        console.log('3. Use MCP tools like mcp__claude-recall__store_memory');
+        console.log('3. Use MCP tools like store_memory (Claude Code adds the mcp__claude-recall__ prefix automatically)');
 
       } catch (error) {
         console.error('❌ Test failed:', error);

--- a/src/mcp/tools/memory-tools.ts
+++ b/src/mcp/tools/memory-tools.ts
@@ -164,7 +164,7 @@ export class MemoryTools {
   private registerTools(): void {
     this.tools = [
       {
-        name: 'mcp__claude-recall__load_rules',
+        name: 'load_rules',
         description: 'Load all active rules before starting work. Returns preferences, corrections, past failures, and devops rules. Call this once at the start of every task. No query needed.',
         inputSchema: {
           type: 'object',
@@ -178,7 +178,7 @@ export class MemoryTools {
         handler: this.handleLoadRules.bind(this)
       },
       {
-        name: 'mcp__claude-recall__store_memory',
+        name: 'store_memory',
         description: 'Store a rule or learning. Use for: corrections, preferences, devops rules, failures. The stored rule is immediately active in this conversation.',
         inputSchema: {
           type: 'object',
@@ -202,7 +202,7 @@ export class MemoryTools {
         handler: this.handleStoreMemory.bind(this)
       },
       {
-        name: 'mcp__claude-recall__search_memory',
+        name: 'search_memory',
         description: 'Search memories by keyword. Use to find specific memories before making decisions. Returns matched memories ranked by relevance.',
         inputSchema: {
           type: 'object',
@@ -229,7 +229,7 @@ export class MemoryTools {
         handler: this.handleSearchMemory.bind(this)
       },
       {
-        name: 'mcp__claude-recall__delete_memory',
+        name: 'delete_memory',
         description: 'Delete a specific memory by its ID (key). Use search_memory first to find the ID of the memory to delete.',
         inputSchema: {
           type: 'object',
@@ -244,7 +244,7 @@ export class MemoryTools {
         handler: this.handleDeleteMemory.bind(this)
       },
       {
-        name: 'mcp__claude-recall__save_checkpoint',
+        name: 'save_checkpoint',
         description: 'Save a task checkpoint — a structured snapshot of work in progress (completed/remaining/blockers/notes). Replaces any previous checkpoint for this project. Call when ending a work session or pausing on a task.',
         inputSchema: {
           type: 'object',
@@ -260,7 +260,7 @@ export class MemoryTools {
         handler: this.handleSaveCheckpoint.bind(this),
       },
       {
-        name: 'mcp__claude-recall__load_checkpoint',
+        name: 'load_checkpoint',
         description: 'Load the latest task checkpoint for the current project. Returns null if none exists. Call at the start of a session to recall where you left off — load_rules will hint when one exists.',
         inputSchema: {
           type: 'object',

--- a/tests/integration/claude-code-integration.test.ts
+++ b/tests/integration/claude-code-integration.test.ts
@@ -43,13 +43,13 @@ describe('Claude Code MCP Integration', () => {
 
       // Verify core memory tools are present
       const toolNames = response.result.tools.map((t: any) => t.name);
-      expect(toolNames).toContain('mcp__claude-recall__store_memory');
-      expect(toolNames).toContain('mcp__claude-recall__load_rules');
+      expect(toolNames).toContain('store_memory');
+      expect(toolNames).toContain('load_rules');
     });
 
     it('should have proper tool schemas', async () => {
       const response = await client.request('tools/list', {});
-      const storeMemoryTool = response.result.tools.find((t: any) => t.name === 'mcp__claude-recall__store_memory');
+      const storeMemoryTool = response.result.tools.find((t: any) => t.name === 'store_memory');
       
       expect(storeMemoryTool).toBeDefined();
       expect(storeMemoryTool.inputSchema).toBeDefined();
@@ -63,7 +63,7 @@ describe('Claude Code MCP Integration', () => {
     it('should store and retrieve memories', async () => {
       // Store a memory
       const storeResponse = await client.request('tools/call', {
-        name: 'mcp__claude-recall__store_memory',
+        name: 'store_memory',
         arguments: {
           content: 'Test memory content',
           metadata: { type: 'preference', test: true }
@@ -77,7 +77,7 @@ describe('Claude Code MCP Integration', () => {
 
       // Retrieve it via load_rules
       const rulesResponse = await client.request('tools/call', {
-        name: 'mcp__claude-recall__load_rules',
+        name: 'load_rules',
         arguments: {}
       });
 
@@ -93,7 +93,7 @@ describe('Claude Code MCP Integration', () => {
       };
 
       const storeResponse = await client.request('tools/call', {
-        name: 'mcp__claude-recall__store_memory',
+        name: 'store_memory',
         arguments: {
           content: 'Memory with complex metadata',
           metadata
@@ -110,7 +110,7 @@ describe('Claude Code MCP Integration', () => {
       const timestamp = Date.now();
       for (let i = 0; i < 3; i++) {
         await client.request('tools/call', {
-          name: 'mcp__claude-recall__store_memory',
+          name: 'store_memory',
           arguments: {
             content: `Test preference ${timestamp}-${i}`,
             metadata: { type: 'preference', index: i, testRun: timestamp }
@@ -120,7 +120,7 @@ describe('Claude Code MCP Integration', () => {
 
       // Load rules to verify they're included
       const rulesResponse = await client.request('tools/call', {
-        name: 'mcp__claude-recall__load_rules',
+        name: 'load_rules',
         arguments: {}
       });
 
@@ -133,7 +133,7 @@ describe('Claude Code MCP Integration', () => {
     it('should maintain session across restarts', async () => {
       // Load initial rules count
       const rules1 = await client.request('tools/call', {
-        name: 'mcp__claude-recall__load_rules',
+        name: 'load_rules',
         arguments: {}
       });
 
@@ -142,7 +142,7 @@ describe('Claude Code MCP Integration', () => {
       // Store a unique memory
       const uniqueContent = `Session test preference ${Date.now()}`;
       await client.request('tools/call', {
-        name: 'mcp__claude-recall__store_memory',
+        name: 'store_memory',
         arguments: {
           content: uniqueContent,
           metadata: { type: 'preference', sessionTest: true }
@@ -154,7 +154,7 @@ describe('Claude Code MCP Integration', () => {
 
       // Verify session persisted via load_rules
       const rules2 = await client.request('tools/call', {
-        name: 'mcp__claude-recall__load_rules',
+        name: 'load_rules',
         arguments: {}
       });
 
@@ -166,7 +166,7 @@ describe('Claude Code MCP Integration', () => {
   describe('Error Handling', () => {
     it('should handle invalid tool calls gracefully', async () => {
       const response = await client.request('tools/call', {
-        name: 'mcp__claude-recall__invalid_tool',
+        name: 'invalid_tool',
         arguments: {}
       });
 
@@ -176,7 +176,7 @@ describe('Claude Code MCP Integration', () => {
 
     it('should validate required parameters', async () => {
       const response = await client.request('tools/call', {
-        name: 'mcp__claude-recall__store_memory',
+        name: 'store_memory',
         arguments: {} // Missing required 'content' parameter
       });
 
@@ -190,7 +190,7 @@ describe('Claude Code MCP Integration', () => {
     it('should handle calling removed tools gracefully', async () => {
       // Calling a removed tool should return "Tool not found"
       const response = await client.request('tools/call', {
-        name: 'mcp__claude-recall__clear_context',
+        name: 'clear_context',
         arguments: { confirm: true }
       });
 

--- a/tests/templates/integration-test-template.ts
+++ b/tests/templates/integration-test-template.ts
@@ -84,7 +84,7 @@ describe('YourMCPFeature Integration', () => {
     it('should have proper tool schema', async () => {
       const response = await client.request('tools/list', {});
       const yourTool = response.result.tools.find((t: any) =>
-        t.name === 'mcp__claude-recall__your_tool'
+        t.name === 'your_tool'
       );
 
       expect(yourTool).toBeDefined();
@@ -98,7 +98,7 @@ describe('YourMCPFeature Integration', () => {
     it('should execute tool successfully', async () => {
       // Call your MCP tool
       const response = await client.request('tools/call', {
-        name: 'mcp__claude-recall__your_tool',
+        name: 'your_tool',
         arguments: {
           // Your tool arguments
           param1: 'value1',
@@ -119,7 +119,7 @@ describe('YourMCPFeature Integration', () => {
     it('should handle multiple sequential calls', async () => {
       // First call
       const response1 = await client.request('tools/call', {
-        name: 'mcp__claude-recall__store_memory',
+        name: 'store_memory',
         arguments: {
           content: 'First memory',
           metadata: { order: 1 }
@@ -129,7 +129,7 @@ describe('YourMCPFeature Integration', () => {
 
       // Second call
       const response2 = await client.request('tools/call', {
-        name: 'mcp__claude-recall__store_memory',
+        name: 'store_memory',
         arguments: {
           content: 'Second memory',
           metadata: { order: 2 }
@@ -139,7 +139,7 @@ describe('YourMCPFeature Integration', () => {
 
       // Verify both exist via load_rules
       const rulesResponse = await client.request('tools/call', {
-        name: 'mcp__claude-recall__load_rules',
+        name: 'load_rules',
         arguments: {}
       });
 
@@ -151,7 +151,7 @@ describe('YourMCPFeature Integration', () => {
   describe('Error Handling', () => {
     it('should handle invalid tool name', async () => {
       const response = await client.request('tools/call', {
-        name: 'mcp__claude-recall__nonexistent_tool',
+        name: 'nonexistent_tool',
         arguments: {}
       });
 
@@ -161,7 +161,7 @@ describe('YourMCPFeature Integration', () => {
 
     it('should validate required parameters', async () => {
       const response = await client.request('tools/call', {
-        name: 'mcp__claude-recall__your_tool',
+        name: 'your_tool',
         arguments: {
           // Missing required parameters
         }
@@ -180,7 +180,7 @@ describe('YourMCPFeature Integration', () => {
 
       // Store memory
       await client.request('tools/call', {
-        name: 'mcp__claude-recall__store_memory',
+        name: 'store_memory',
         arguments: {
           content: uniqueContent,
           metadata: { persistent: true }
@@ -189,7 +189,7 @@ describe('YourMCPFeature Integration', () => {
 
       // Retrieve via load_rules
       const rulesResponse = await client.request('tools/call', {
-        name: 'mcp__claude-recall__load_rules',
+        name: 'load_rules',
         arguments: {}
       });
 


### PR DESCRIPTION
## Summary

Fixes #7

- Remove hardcoded `mcp__claude-recall__` prefix from 6 tool names in `memory-tools.ts`
- Update CLI test mock and help text in `claude-recall-cli.ts` for consistency
- Claude Code adds the `mcp__claude-recall__` prefix automatically based on the MCP server name, so hardcoding it causes a doubled prefix (`mcp__claude-recall__mcp__claude-recall__load_rules`)

## Changes

**`src/mcp/tools/memory-tools.ts`** — 6 tool name changes:
| Before | After |
|--------|-------|
| `mcp__claude-recall__load_rules` | `load_rules` |
| `mcp__claude-recall__store_memory` | `store_memory` |
| `mcp__claude-recall__search_memory` | `search_memory` |
| `mcp__claude-recall__delete_memory` | `delete_memory` |
| `mcp__claude-recall__save_checkpoint` | `save_checkpoint` |
| `mcp__claude-recall__load_checkpoint` | `load_checkpoint` |

**`src/cli/claude-recall-cli.ts`** — 2 reference updates (test mock data + help message)

## Notes

- `search_enforcer.py` hook uses substring matching (`any(s in tool_name for s in SEARCH_TOOLS)`), so it continues to work without changes
- `rule-injector.ts` uses `toolName.startsWith('mcp__claude-recall__')` which matches the final prefixed name — no changes needed
- Pi extension uses `recall_` prefix (different naming convention) — unaffected

## Test plan

- [ ] Build project with `npm run build`
- [ ] Start MCP server and verify tool names are registered without double prefix
- [ ] Verify `search_enforcer` hook accepts `load_rules` call
- [ ] Verify all 6 tools are callable from Claude Code