### PR TITLE
feat: add session-preseed hook to prevent tool blocking on startup

### DIFF
--- a/src/cli/claude-recall-cli.ts
+++ b/src/cli/claude-recall-cli.ts
@@ -913,6 +913,16 @@ async function main() {
               timeout: 10
             }
           ]
+        },
+        {
+          matcher: "startup",
+          hooks: [
+            {
+              type: "command",
+              command: `${hookCmd} session-preseed`,
+              timeout: 5
+            }
+          ]
         }
       ],
       PostToolUse: [

--- a/src/cli/commands/hook-commands.ts
+++ b/src/cli/commands/hook-commands.ts
@@ -94,6 +94,11 @@ export class HookCommands {
               await handleRuleInjectionResolver(input);
               break;
             }
+            case 'session-preseed': {
+              const { handleSessionPreseed } = await import('../../hooks/session-preseed');
+              await handleSessionPreseed(input);
+              break;
+            }
             default:
               console.error(`Unknown hook: ${name}`);
               console.error('Available: correction-detector, memory-stop, precompact-preserve, memory-sync, tool-outcome-watcher, session-end-checkpoint');

--- a/src/hooks/session-preseed.ts
+++ b/src/hooks/session-preseed.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Session Preseed Hook
+ *
+ * Pre-seeds the search_enforcer hook state at session start so that
+ * tools are not blocked before load_rules is called.
+ *
+ * Without this, the search_enforcer blocks Read/Bash/Edit until
+ * load_rules is explicitly called, which creates a deadlock because
+ * Claude often needs to read files before it knows to call load_rules.
+ *
+ * The preseed sets lastSearchAt to the current time, allowing the
+ * enforcer to pass through. The actual load_rules call will happen
+ * naturally during the session and refresh the state with real data.
+ */
+export async function handleSessionPreseed(input: string): Promise<void> {
+  try {
+    const parsed = JSON.parse(input || '{}');
+    const sessionId = parsed.session_id || 'default';
+
+    const stateDir = path.join(
+      process.env.HOME || process.env.USERPROFILE || '.',
+      '.claude-recall',
+      'hook-state'
+    );
+
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const safeId = sessionId.replace(/[^a-zA-Z0-9_-]/g, '_') || 'default';
+    const stateFile = path.join(stateDir, `${safeId}.json`);
+
+    const state = {
+      lastSearchAt: Date.now(),
+      searchQuery: 'preseed-session-start',
+      blockCount: 0
+    };
+
+    fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
+  } catch {
+    // Hooks must never block Claude — silently fail
+  }
+}


### PR DESCRIPTION
## Summary

Related to #7

The `search_enforcer` hook blocks all tools (Read, Bash, Edit, etc.) until `load_rules` is called. This creates a deadlock on session start: Claude needs tools to work, but tools are blocked until `load_rules` runs, and Claude doesn't know to call `load_rules` first.

Currently the circuit breaker degrades after 3 blocks, but users experience 3 failed tool calls every session start.

## Solution

Add a `session-preseed` SessionStart hook that pre-seeds the enforcer state file with the current timestamp. This:

1. Allows tools to pass through immediately on session start
2. Preserves the enforcer's purpose — `load_rules` still runs naturally during the session
3. Gets auto-configured via `claude-recall setup --install`

## Changes

| File | Change |
|------|--------|
| `src/hooks/session-preseed.ts` | New hook handler — writes preseed state file |
| `src/cli/commands/hook-commands.ts` | Register `session-preseed` in dispatcher |
| `src/cli/claude-recall-cli.ts` | Add SessionStart hook with `startup` matcher |

## Test plan

- [ ] Run `claude-recall setup --install` and verify SessionStart hooks include `session-preseed`
- [ ] Start a new Claude Code session — tools should work immediately without 3 blocked attempts
- [ ] Verify `load_rules` still works when called explicitly
- [ ] Verify `~/.claude-recall/hook-state/{session}.json` is created on startup