### PR TITLE
fix(upgrade): always scan for stale local installs (0.24.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.2] - 2026-04-24
+
+### Fixed
+
+- **`claude-recall upgrade` now scans for stale local installs even when already up-to-date.** 0.24.1 added the scan but only ran it after a successful upgrade — users on the latest version had no way to invoke just the diagnostic. Now the scan runs on every `claude-recall upgrade` invocation regardless of whether a version change happened, so:
+  - `claude-recall upgrade` on an outdated global → upgrades + scans (as before)
+  - `claude-recall upgrade` on a current global → scans only (now acts as a diagnostic)
+  - `claude-recall upgrade --clean-locals` → always scans, auto-removes anything found, works even with no upgrade pending
+
+  Note: this also addresses the chicken-and-egg from 0.24.0 → 0.24.1 — users who upgraded with the old 0.24.0 binary never saw the scan run, because the running process didn't have the new code. Re-running `claude-recall upgrade` on 0.24.2+ from the same machine now invokes the scan whether or not an install is needed.
+
 ## [0.24.1] - 2026-04-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-recall",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Persistent memory for Claude Code and Pi with native Skills integration, automatic capture, failure learning, and project scoping",
   "main": "dist/index.js",
   "bin": {

--- a/src/cli/claude-recall-cli.ts
+++ b/src/cli/claude-recall-cli.ts
@@ -396,48 +396,55 @@ class ClaudeRecallCLI {
     console.log(`Installed: ${current}`);
     console.log(`Latest:    ${latest}`);
 
-    if (current === latest) {
-      console.log('\n✓ Already up to date.');
-      return;
+    const needsInstall = current !== latest;
+
+    if (needsInstall) {
+      console.log(`\n📦 Upgrading ${current} → ${latest}...\n`);
+
+      // Run npm install -g, streaming output so the user sees progress / errors live
+      const install = spawnSync('npm', ['install', '-g', 'claude-recall@latest'], {
+        stdio: 'inherit',
+      });
+
+      if (install.status !== 0) {
+        // npm prints its own error — add the practical remediation on top
+        console.error('\n❌ Install failed.');
+        console.error('\nMost common cause: your global npm prefix is owned by root (EACCES).');
+        console.error('\nQuick fix:');
+        console.error('  sudo npm install -g claude-recall');
+        console.error('\nPermanent fix (no more sudo for any global install on this machine):');
+        console.error('  mkdir -p ~/.npm-global');
+        console.error("  npm config set prefix ~/.npm-global");
+        console.error("  echo 'export PATH=~/.npm-global/bin:$PATH' >> ~/.bashrc");
+        console.error('  source ~/.bashrc');
+        console.error('\nThen re-run: claude-recall upgrade');
+        process.exit(install.status ?? 1);
+      }
+
+      // Kill any running MCP servers so Claude Code respawns them with the new binary
+      console.log('\n🧹 Cleaning up running MCP servers (Claude Code respawns them on next tool call)...');
+      try {
+        spawnSync('claude-recall', ['mcp', 'cleanup', '--all'], { stdio: 'inherit' });
+      } catch {
+        // Non-fatal — the user can restart Claude Code manually if this fails
+      }
     }
 
-    console.log(`\n📦 Upgrading ${current} → ${latest}...\n`);
-
-    // Run npm install -g, streaming output so the user sees progress / errors live
-    const install = spawnSync('npm', ['install', '-g', 'claude-recall@latest'], {
-      stdio: 'inherit',
-    });
-
-    if (install.status !== 0) {
-      // npm prints its own error — add the practical remediation on top
-      console.error('\n❌ Install failed.');
-      console.error('\nMost common cause: your global npm prefix is owned by root (EACCES).');
-      console.error('\nQuick fix:');
-      console.error('  sudo npm install -g claude-recall');
-      console.error('\nPermanent fix (no more sudo for any global install on this machine):');
-      console.error('  mkdir -p ~/.npm-global');
-      console.error("  npm config set prefix ~/.npm-global");
-      console.error("  echo 'export PATH=~/.npm-global/bin:$PATH' >> ~/.bashrc");
-      console.error('  source ~/.bashrc');
-      console.error('\nThen re-run: claude-recall upgrade');
-      process.exit(install.status ?? 1);
-    }
-
-    // Kill any running MCP servers so Claude Code respawns them with the new binary
-    console.log('\n🧹 Cleaning up running MCP servers (Claude Code respawns them on next tool call)...');
-    try {
-      spawnSync('claude-recall', ['mcp', 'cleanup', '--all'], { stdio: 'inherit' });
-    } catch {
-      // Non-fatal — the user can restart Claude Code manually if this fails
-    }
-
-    // Detect stale project-local installs that would shadow the just-installed
-    // global binary when invoked via `npx claude-recall`.
+    // Detect stale project-local installs that would shadow the global binary
+    // when invoked via `npx claude-recall`. Runs on every upgrade invocation,
+    // including when already up-to-date — so `claude-recall upgrade` doubles
+    // as a diagnostic for the npx-walks-up-and-finds-stale-local trap, and
+    // `claude-recall upgrade --clean-locals` works as a one-shot cleanup
+    // command even when no version change is pending.
     this.warnOrCleanStaleLocals(latest, opts.cleanLocals === true);
 
-    console.log(`\n✓ Upgraded to ${latest}. No need to re-run \`claude mcp add\` — existing`);
-    console.log('  registrations point at the `claude-recall` command and pick up the new');
-    console.log('  binary automatically. Just run any tool in Claude Code.');
+    if (needsInstall) {
+      console.log(`\n✓ Upgraded to ${latest}. No need to re-run \`claude mcp add\` — existing`);
+      console.log('  registrations point at the `claude-recall` command and pick up the new');
+      console.log('  binary automatically. Just run any tool in Claude Code.');
+    } else {
+      console.log('\n✓ Already up to date.');
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Run the stale-local-install scan on every \`claude-recall upgrade\` invocation, not just when an actual upgrade happens
- Lets users on the current version use \`claude-recall upgrade --clean-locals\` as a one-shot diagnostic + cleanup tool
- Also addresses the 0.24.0 → 0.24.1 chicken-and-egg: the OLD 0.24.0 binary ran the upgrade and never executed the new scan code

## Test plan
- [x] \`npm run build\` clean
- [x] \`npm test\` 473/473
- [x] \`npm run check:publish\` clean
- [ ] CI: publish-check passes
- [ ] After publish: \`claude-recall upgrade\` on a current install reports stale locals (or \"no stale installs found\" silently)
- [ ] \`claude-recall upgrade --clean-locals\` actually removes them