### PR TITLE
feat(repair): conservative hook-path fixer + postinstall auto-heal (0.25.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`claude-recall repair` is now a conservative hook-path fixer by default, runnable on any machine.** Motivated by a real stale-hook failure on a user's VM where `~/.claude/settings.json` pointed at `/home/USER/node_modules/claude-recall/dist/cli/claude-recall-cli.js` — a path that no longer existed, so every `Stop` / `UserPromptSubmit` / `PreCompact` hook threw `MODULE_NOT_FOUND`. Running `claude-recall repair` now:
+  - Scans user-global (`~/.claude/settings.json` + `settings.local.json`) and the closest project (`.claude/settings.json`) settings files.
+  - Finds hooks whose commands reference claude-recall but point at a missing absolute script path.
+  - If `claude-recall` is on PATH, rewrites those commands to the portable `claude-recall hook run <id>` form — preserving each hook's `timeout`, each group's `matcher`, and every sibling (non-claude-recall) hook verbatim. If `claude-recall` is not on PATH, reports the issue and exits 0 with install instructions.
+  - Writes a `<path>.bak.<iso-timestamp>` before any mutation.
+  - **Does not touch `hooksVersion`, does not re-install missing hooks, and does not rewrite non-claude-recall hooks.**
+  - New flags: `--auto` (non-interactive), `--dry-run` (report only), `--scope user|project|all`, `--reinstall-hooks` (legacy opinionated path that rewrites the whole block from the current template; `--force` kept as an alias for backwards compatibility).
+- **`postinstall` now runs `claude-recall repair --auto --scope user` on upgrade.** Self-heals the common "global claude-recall moved/renamed and left stale hook commands in `~/.claude/settings.json`" failure without ever installing hooks where none exist (which would repeat the 0.24.0 clobber bug). Non-fatal if it errors — `npm install` always succeeds.
+
 ## [0.24.2] - 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.25.0] - 2026-04-24
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,9 @@ tail -20 ~/.claude-recall/hook-logs/memory-stop.log
 tail -20 ~/.claude-recall/hook-logs/correction-detector.log
 
 # "Something is broken, start fresh"
-claude-recall repair                     # Clean up old hooks, reinstall skills
+claude-recall repair                     # Conservative: fix broken hook paths in settings.json (preserves your customizations)
+claude-recall repair --dry-run           # Preview what repair would change
+claude-recall repair --reinstall-hooks   # Opinionated: rewrite entire hook block from current template
 claude-recall setup --install            # Reinstall skills + hooks
 claude-recall mcp cleanup --all          # Stop all stale MCP servers
 ```
@@ -305,7 +307,11 @@ claude-recall setup                      # Show activation instructions
 claude-recall setup --install            # Install skills + hooks
 claude-recall upgrade                    # One-shot upgrade: global binary + clear stale MCP servers
 claude-recall status                     # Installation and system status
-claude-recall repair                     # Clean up old hooks, install skills
+claude-recall repair                     # Fix broken claude-recall hook paths (conservative: preserves user customizations)
+claude-recall repair --auto              # Non-interactive; apply safe fixes without prompting (used by postinstall)
+claude-recall repair --dry-run           # Report what would change without writing
+claude-recall repair --scope user|project|all  # Scope the scan (default: all)
+claude-recall repair --reinstall-hooks   # Opinionated: rewrite entire hook block from current template
 claude-recall hooks check                # Verify hook files exist and are valid
 claude-recall hooks test-enforcement     # Test if search enforcer hook works
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-recall",
-  "version": "0.24.2",
+  "version": "0.25.0",
   "description": "Persistent memory for Claude Code and Pi with native Skills integration, automatic capture, failure learning, and project scoping",
   "main": "dist/index.js",
   "bin": {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -117,6 +117,30 @@ try {
   // `claude-recall setup` invocation by the user, which is conscious and
   // produces a diff the user can see.
 
+  // Conservative repair on upgrade: fix broken absolute hook paths in
+  // ~/.claude/settings.json that reference a defunct claude-recall install
+  // (common when node/nvm versions change, or when the package was reinstalled
+  // into a different location). The --auto --scope user flags mean:
+  //   • only user-global settings are touched (no project files)
+  //   • only commands pointing at MISSING absolute scripts get rewritten
+  //   • user customizations (timeouts, matchers, sibling hooks) preserved
+  //   • writes a .bak.<timestamp> before any change
+  //   • never installs hooks where none exist — satisfies the "don't clobber"
+  //     rule above
+  try {
+    const cliPath = path.join(__dirname, '..', 'dist', 'cli', 'claude-recall-cli.js');
+    if (fs.existsSync(cliPath)) {
+      execSync(`node "${cliPath}" repair --auto --scope user`, {
+        stdio: 'inherit',
+        timeout: 15000
+      });
+    }
+  } catch (repairError) {
+    // Non-fatal: postinstall must never fail the npm install. Any repair
+    // problem can be fixed manually with `claude-recall repair`.
+    console.log('⚠️  Auto-repair skipped (non-fatal):', repairError.message);
+  }
+
   console.log('\n✅ Installation complete!\n');
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   console.log('📌 ACTIVATE CLAUDE RECALL:');

--- a/src/cli/claude-recall-cli.ts
+++ b/src/cli/claude-recall-cli.ts
@@ -17,6 +17,7 @@ import { MCPCommands } from './commands/mcp-commands';
 import { ProjectCommands } from './commands/project-commands';
 import { HookCommands } from './commands/hook-commands';
 import { OutcomeStorage } from '../services/outcome-storage';
+import { runRepair } from './commands/repair';
 
 const program = new Command();
 
@@ -1383,14 +1384,40 @@ async function main() {
       process.exit(0);
     });
 
-  // Repair command - cleans up old hooks and installs skills
+  // Repair command — conservative by default: fix broken hook paths without
+  // touching user customizations. --reinstall-hooks (or legacy --force) runs
+  // the opinionated installer that rewrites the entire hook block from template.
   program
     .command('repair')
-    .description('Clean up old hooks and install skills (v0.9.0+ migration)')
-    .option('--force', 'Force overwrite existing configuration')
-    .action((options) => {
-      installSkillsAndHook(options.force || false);
-      process.exit(0);
+    .description('Fix broken claude-recall hook paths in settings.json (conservative)')
+    .option('--auto', 'Non-interactive; apply safe fixes without prompting')
+    .option('--dry-run', 'Report what would change without writing any files')
+    .option('--reinstall-hooks', 'Rewrite the entire hook block from current template (opinionated)')
+    .option('--scope <scope>', 'user | project | all', 'all')
+    .option('--force', '[deprecated alias for --reinstall-hooks]')
+    .action(async (options) => {
+      if (options.reinstallHooks || options.force) {
+        installSkillsAndHook(true);
+        process.exit(0);
+      }
+      const scope = (options.scope || 'all') as 'user' | 'project' | 'all';
+      if (!['user', 'project', 'all'].includes(scope)) {
+        console.error(`Invalid --scope: ${scope}. Use user, project, or all.`);
+        process.exit(2);
+      }
+      try {
+        const result = await runRepair({
+          auto: !!options.auto,
+          dryRun: !!options.dryRun,
+          scope,
+        });
+        process.exit(result.exitCode);
+      } catch (err) {
+        // Never crash postinstall. Log and exit 0 on unexpected errors so
+        // `npm install` continues. Surface via non-zero only for interactive runs.
+        console.error(`repair: unexpected error: ${(err as Error).message}`);
+        process.exit(options.auto ? 0 : 1);
+      }
     });
 
   // Check hooks function

--- a/src/cli/commands/repair.ts
+++ b/src/cli/commands/repair.ts
@@ -1,0 +1,459 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+export interface HookEntry {
+  type: string;
+  command: string;
+  timeout?: number;
+  [k: string]: unknown;
+}
+
+export interface HookGroup {
+  matcher?: string;
+  hooks?: HookEntry[];
+  [k: string]: unknown;
+}
+
+export interface SettingsShape {
+  hooks?: Record<string, HookGroup[]>;
+  hooksVersion?: string;
+  [k: string]: unknown;
+}
+
+export type Classification =
+  | { status: 'ok' }
+  | { status: 'non-claude-recall' }
+  | { status: 'broken-absolute'; scriptPath: string; hookId: string | null }
+  | { status: 'broken-path'; binary: string; hookId: string | null };
+
+export interface HookLocation {
+  settingsPath: string;
+  event: string;
+  groupIndex: number;
+  hookIndex: number;
+}
+
+export interface Finding {
+  location: HookLocation;
+  originalCommand: string;
+  classification: Classification;
+  proposedCommand?: string;
+}
+
+export interface FileReport {
+  settingsPath: string;
+  parseError?: string;
+  hooksVersion?: string;
+  findings: Finding[];
+}
+
+export interface RepairOptions {
+  auto?: boolean;
+  dryRun?: boolean;
+  scope?: 'user' | 'project' | 'all';
+  cwd?: string;
+  home?: string;
+  logger?: {
+    log: (msg: string) => void;
+    warn: (msg: string) => void;
+  };
+  /** Override for tests: whether the `claude-recall` binary resolves on PATH. */
+  claudeRecallOnPath?: () => string | null;
+  /** Override for tests: interactive y/N prompt. Defaults to non-interactive (false) unless provided. */
+  prompt?: (question: string) => Promise<boolean>;
+}
+
+export interface RepairResult {
+  exitCode: number;
+  filesScanned: number;
+  filesModified: number;
+  fixesApplied: number;
+  unfixable: number;
+  reports: FileReport[];
+}
+
+const CLAUDE_RECALL_CLI_RE = /claude[-_]recall[-_]cli(?:\.js)?/i;
+const HOOK_RUN_ID_RE = /hook\s+run\s+(\S+)/i;
+
+/**
+ * Resolve a binary name against PATH. POSIX-first; on Windows tries common
+ * extensions. Returns the first matching absolute path, or null.
+ */
+export function resolveOnPath(binName: string): string | null {
+  const pathEnv = process.env.PATH || '';
+  const exts = process.platform === 'win32' ? ['.cmd', '.exe', '.bat', ''] : [''];
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const candidate = path.join(dir, binName + ext);
+      try {
+        const st = fs.statSync(candidate);
+        if (st.isFile()) return candidate;
+      } catch {
+        // not present — keep looking
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Decide whether a hook command belongs to claude-recall and, if so, whether
+ * its invocation target actually resolves on disk / on PATH. Pure function —
+ * no I/O except for the filesystem check on absolute script paths and the
+ * PATH probe (which the caller can stub via `claudeRecallResolver`).
+ */
+export function classifyHook(
+  command: string,
+  claudeRecallResolver: () => string | null
+): Classification {
+  const trimmed = command.trim();
+  if (!trimmed) return { status: 'non-claude-recall' };
+
+  const tokens = trimmed.split(/\s+/);
+  const first = tokens[0] || '';
+  const base = path.basename(first);
+
+  const looksLikeCR =
+    CLAUDE_RECALL_CLI_RE.test(trimmed) ||
+    base === 'claude-recall' ||
+    /\bclaude-recall\b/.test(trimmed);
+
+  if (!looksLikeCR) return { status: 'non-claude-recall' };
+
+  const hookIdMatch = trimmed.match(HOOK_RUN_ID_RE);
+  const hookId = hookIdMatch ? hookIdMatch[1] : null;
+
+  // Case A: `node /abs/path/to/claude-recall-cli.js hook run ...`
+  //         or `/abs/path/to/node /abs/path/.../claude-recall-cli.js ...`
+  if (base === 'node' || /\/node$/.test(first)) {
+    const script = tokens[1];
+    if (script && path.isAbsolute(script) && CLAUDE_RECALL_CLI_RE.test(script)) {
+      if (!fs.existsSync(script)) {
+        return { status: 'broken-absolute', scriptPath: script, hookId };
+      }
+      return { status: 'ok' };
+    }
+    // Unusual node invocation we don't recognize — don't touch.
+    return { status: 'ok' };
+  }
+
+  // Case B: `claude-recall hook run ...` (PATH-resolved form — what we rewrite to)
+  if (base === 'claude-recall') {
+    if (claudeRecallResolver()) return { status: 'ok' };
+    return { status: 'broken-path', binary: 'claude-recall', hookId };
+  }
+
+  // Case C: `npx claude-recall ...` — npx resolves at runtime; treat as OK.
+  if (base === 'npx') return { status: 'ok' };
+
+  // Anything else mentioning claude-recall — leave alone.
+  return { status: 'ok' };
+}
+
+/**
+ * Given the closest settings.json-like file path, return the list of paths
+ * to scan (settings.json + settings.local.json if present).
+ */
+function pickSiblings(settingsPath: string): string[] {
+  const dir = path.dirname(settingsPath);
+  const out: string[] = [];
+  for (const name of ['settings.json', 'settings.local.json']) {
+    const p = path.join(dir, name);
+    if (fs.existsSync(p)) out.push(p);
+  }
+  return out;
+}
+
+export function findSettingsFiles(
+  cwd: string,
+  home: string,
+  scope: 'user' | 'project' | 'all'
+): string[] {
+  const results: string[] = [];
+
+  if (scope === 'user' || scope === 'all') {
+    const userDir = path.join(home, '.claude');
+    for (const p of pickSiblings(path.join(userDir, 'settings.json'))) {
+      if (!results.includes(p)) results.push(p);
+    }
+  }
+
+  if (scope === 'project' || scope === 'all') {
+    // Walk up looking for the CLOSEST .claude dir containing a settings file
+    // (matches Claude Code's own resolution). We don't scan ancestors beyond
+    // the first match — those belong to other projects.
+    let dir = cwd;
+    while (dir !== path.dirname(dir)) {
+      const claudeDir = path.join(dir, '.claude');
+      const s = path.join(claudeDir, 'settings.json');
+      const l = path.join(claudeDir, 'settings.local.json');
+      const hasAny = fs.existsSync(s) || fs.existsSync(l);
+      if (hasAny) {
+        if (fs.existsSync(s) && !results.includes(s)) results.push(s);
+        if (fs.existsSync(l) && !results.includes(l)) results.push(l);
+        break;
+      }
+      dir = path.dirname(dir);
+    }
+  }
+
+  return results;
+}
+
+export function scanFile(
+  settingsPath: string,
+  claudeRecallResolver: () => string | null
+): FileReport {
+  const report: FileReport = { settingsPath, findings: [] };
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(settingsPath, 'utf8');
+  } catch (e) {
+    report.parseError = `cannot read: ${(e as Error).message}`;
+    return report;
+  }
+
+  let parsed: SettingsShape;
+  try {
+    parsed = JSON.parse(raw) as SettingsShape;
+  } catch (e) {
+    report.parseError = `invalid JSON: ${(e as Error).message}`;
+    return report;
+  }
+
+  if (typeof parsed.hooksVersion === 'string') {
+    report.hooksVersion = parsed.hooksVersion;
+  }
+
+  const hooks = parsed.hooks;
+  if (!hooks || typeof hooks !== 'object') return report;
+
+  const hasCR = (): string | null => claudeRecallResolver();
+  // Cache resolver result within a single scan to avoid hammering stat().
+  let cached: string | null | undefined;
+  const cachingResolver = () => {
+    if (cached === undefined) cached = hasCR();
+    return cached ?? null;
+  };
+
+  for (const [event, groups] of Object.entries(hooks)) {
+    if (!Array.isArray(groups)) continue;
+    groups.forEach((group, groupIndex) => {
+      if (!group || !Array.isArray(group.hooks)) return;
+      group.hooks.forEach((hook, hookIndex) => {
+        if (!hook || typeof hook.command !== 'string') return;
+        const classification = classifyHook(hook.command, cachingResolver);
+        if (classification.status === 'non-claude-recall') return;
+
+        const finding: Finding = {
+          location: { settingsPath, event, groupIndex, hookIndex },
+          originalCommand: hook.command,
+          classification,
+        };
+
+        if (classification.status === 'broken-absolute') {
+          const crPath = cachingResolver();
+          if (crPath) {
+            const id = classification.hookId;
+            if (id) {
+              finding.proposedCommand = `claude-recall hook run ${id}`;
+            }
+            // If we can't extract a hook id we don't know what subcommand to
+            // invoke. Leave proposedCommand unset — reported as unfixable.
+          }
+        }
+
+        report.findings.push(finding);
+      });
+    });
+  }
+
+  return report;
+}
+
+export function applyFixes(
+  report: FileReport,
+  opts: { dryRun: boolean }
+): { changed: boolean; applied: number; backupPath: string | null } {
+  if (report.parseError) return { changed: false, applied: 0, backupPath: null };
+  const fixable = report.findings.filter(f => f.proposedCommand);
+  if (fixable.length === 0) return { changed: false, applied: 0, backupPath: null };
+
+  const raw = fs.readFileSync(report.settingsPath, 'utf8');
+  const parsed = JSON.parse(raw) as SettingsShape;
+  if (!parsed.hooks) return { changed: false, applied: 0, backupPath: null };
+
+  let applied = 0;
+  for (const f of fixable) {
+    const { event, groupIndex, hookIndex } = f.location;
+    const group = parsed.hooks[event]?.[groupIndex];
+    const entry = group?.hooks?.[hookIndex];
+    if (!entry) continue;
+    // Sanity: only rewrite if the command still matches what we scanned.
+    if (entry.command !== f.originalCommand) continue;
+    entry.command = f.proposedCommand!;
+    applied++;
+  }
+
+  if (applied === 0) return { changed: false, applied: 0, backupPath: null };
+
+  if (opts.dryRun) {
+    return { changed: true, applied, backupPath: null };
+  }
+
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = `${report.settingsPath}.bak.${ts}`;
+  fs.writeFileSync(backupPath, raw);
+  fs.writeFileSync(report.settingsPath, JSON.stringify(parsed, null, 2));
+  return { changed: true, applied, backupPath };
+}
+
+function classify(finding: Finding): 'fixable' | 'unfixable' | 'ok' {
+  const c = finding.classification;
+  if (c.status === 'ok' || c.status === 'non-claude-recall') return 'ok';
+  return finding.proposedCommand ? 'fixable' : 'unfixable';
+}
+
+function describe(finding: Finding): string {
+  const c = finding.classification;
+  const loc = `${finding.location.event}[${finding.location.groupIndex}].hooks[${finding.location.hookIndex}]`;
+  if (c.status === 'broken-absolute') {
+    return `${loc}  missing script: ${c.scriptPath}`;
+  }
+  if (c.status === 'broken-path') {
+    return `${loc}  '${c.binary}' not on PATH`;
+  }
+  return `${loc}  ok`;
+}
+
+export async function runRepair(options: RepairOptions = {}): Promise<RepairResult> {
+  const log = options.logger ?? { log: console.log.bind(console), warn: console.warn.bind(console) };
+  const cwd = options.cwd ?? process.cwd();
+  const home = options.home ?? os.homedir();
+  const scope = options.scope ?? 'all';
+  const resolver = options.claudeRecallOnPath ?? (() => resolveOnPath('claude-recall'));
+
+  log.log('\n🩺 Claude Recall repair (conservative)\n');
+  const files = findSettingsFiles(cwd, home, scope);
+
+  if (files.length === 0) {
+    log.log(`No settings files found (scope: ${scope}).`);
+    log.log('Nothing to repair. If you meant to install hooks, run:');
+    log.log('  claude-recall setup --install\n');
+    return { exitCode: 0, filesScanned: 0, filesModified: 0, fixesApplied: 0, unfixable: 0, reports: [] };
+  }
+
+  const reports: FileReport[] = [];
+  let totalFixable = 0;
+  let totalUnfixable = 0;
+  let totalOk = 0;
+
+  for (const f of files) {
+    const report = scanFile(f, resolver);
+    reports.push(report);
+    if (report.parseError) {
+      log.warn(`  ⚠  ${f}: ${report.parseError}`);
+      continue;
+    }
+    let fixable = 0, unfixable = 0, ok = 0;
+    for (const finding of report.findings) {
+      const kind = classify(finding);
+      if (kind === 'fixable') fixable++;
+      else if (kind === 'unfixable') unfixable++;
+      else ok++;
+    }
+    totalFixable += fixable;
+    totalUnfixable += unfixable;
+    totalOk += ok;
+
+    const versionTag = report.hooksVersion ? ` (hooksVersion: ${report.hooksVersion})` : '';
+    log.log(`  ${f}${versionTag}`);
+    log.log(`    ${ok} OK, ${fixable} fixable, ${unfixable} unfixable`);
+    for (const finding of report.findings) {
+      if (classify(finding) === 'ok') continue;
+      log.log(`    - ${describe(finding)}`);
+      if (finding.proposedCommand) {
+        log.log(`        proposed: ${finding.proposedCommand}`);
+      }
+    }
+  }
+
+  if (totalFixable === 0) {
+    if (totalUnfixable > 0) {
+      log.log(`\n${totalUnfixable} broken claude-recall hook(s) found but no safe fix available.`);
+      log.log('Install claude-recall on PATH so repair can rewrite the broken paths:');
+      log.log('  npm install -g claude-recall\n');
+      // Don't fail postinstall — user's current install was fine until their
+      // PATH/hook config drifted; this is diagnostic, not an error.
+      return {
+        exitCode: 0,
+        filesScanned: files.length,
+        filesModified: 0,
+        fixesApplied: 0,
+        unfixable: totalUnfixable,
+        reports,
+      };
+    }
+    log.log(`\n✅ All ${totalOk} claude-recall hook(s) look healthy. Nothing to do.\n`);
+    return {
+      exitCode: 0,
+      filesScanned: files.length,
+      filesModified: 0,
+      fixesApplied: 0,
+      unfixable: 0,
+      reports,
+    };
+  }
+
+  if (!options.auto && !options.dryRun && options.prompt) {
+    const proceed = await options.prompt(`\nApply ${totalFixable} fix(es)? [y/N] `);
+    if (!proceed) {
+      log.log('Aborted. No files changed.\n');
+      return {
+        exitCode: 0,
+        filesScanned: files.length,
+        filesModified: 0,
+        fixesApplied: 0,
+        unfixable: totalUnfixable,
+        reports,
+      };
+    }
+  }
+
+  let filesModified = 0;
+  let fixesApplied = 0;
+  for (const report of reports) {
+    const { changed, applied, backupPath } = applyFixes(report, { dryRun: !!options.dryRun });
+    if (changed && !options.dryRun) {
+      filesModified++;
+      fixesApplied += applied;
+      log.log(`  ✓ ${report.settingsPath}: applied ${applied} fix(es)`);
+      if (backupPath) log.log(`    backup: ${backupPath}`);
+    } else if (changed && options.dryRun) {
+      fixesApplied += applied;
+      log.log(`  (dry-run) ${report.settingsPath}: would apply ${applied} fix(es)`);
+    }
+  }
+
+  if (options.dryRun) {
+    log.log(`\nDry run complete. ${fixesApplied} fix(es) would be applied across ${reports.filter(r => r.findings.some(f => f.proposedCommand)).length} file(s).\n`);
+  } else {
+    log.log(`\n✅ Repaired ${fixesApplied} hook(s) across ${filesModified} file(s).`);
+    if (totalUnfixable > 0) {
+      log.log(`   ${totalUnfixable} issue(s) still need manual attention (see above).`);
+    }
+    log.log('');
+  }
+
+  return {
+    exitCode: 0,
+    filesScanned: files.length,
+    filesModified,
+    fixesApplied,
+    unfixable: totalUnfixable,
+    reports,
+  };
+}

--- a/tests/integration/repair-cli.test.ts
+++ b/tests/integration/repair-cli.test.ts
@@ -1,0 +1,180 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { spawnSync } from 'child_process';
+
+/**
+ * Integration tests for the `repair` CLI subcommand.
+ *
+ * These tests spawn the compiled CLI at dist/cli/claude-recall-cli.js. If the
+ * build output is missing they skip with a warning — run `npm run build`
+ * before `npm test` to execute them.
+ */
+
+const CLI = path.join(__dirname, '..', '..', 'dist', 'cli', 'claude-recall-cli.js');
+const distBuilt = fs.existsSync(CLI);
+const itIfBuilt = distBuilt ? it : it.skip;
+
+function mkTmp(prefix = 'repair-cli-'): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function rmTmp(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function runCli(args: string[], opts: { cwd?: string; env?: NodeJS.ProcessEnv } = {}) {
+  // Use process.execPath so PATH-scrubbed tests can still launch node.
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: 'utf8',
+    cwd: opts.cwd,
+    env: opts.env ?? process.env,
+    timeout: 15000,
+  });
+}
+
+describe('repair CLI (integration)', () => {
+  beforeAll(() => {
+    if (!distBuilt) {
+      // eslint-disable-next-line no-console
+      console.warn(`[repair-cli.test] skipping — build first with 'npm run build' (missing ${CLI})`);
+    }
+  });
+
+  itIfBuilt('--dry-run reports fixable issues and leaves file unchanged', () => {
+    const tmpHome = mkTmp();
+    try {
+      const claudeDir = path.join(tmpHome, '.claude');
+      fs.mkdirSync(claudeDir);
+      const settingsPath = path.join(claudeDir, 'settings.json');
+      const original = {
+        hooksVersion: '6.0.0',
+        hooks: {
+          Stop: [{
+            hooks: [{
+              type: 'command',
+              command: 'node /does/not/exist/claude-recall-cli.js hook run memory-stop',
+              timeout: 30,
+            }],
+          }],
+        },
+      };
+      fs.writeFileSync(settingsPath, JSON.stringify(original));
+
+      const res = runCli(['repair', '--dry-run', '--auto', '--scope', 'user'], {
+        env: { ...process.env, HOME: tmpHome },
+      });
+      expect(res.status).toBe(0);
+      expect(res.stdout + res.stderr).toMatch(/broken-absolute|missing script|fixable/i);
+
+      const after = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      expect(after).toEqual(original);
+      expect(fs.readdirSync(claudeDir).filter(n => n.startsWith('settings.json.bak')))
+        .toEqual([]);
+    } finally {
+      rmTmp(tmpHome);
+    }
+  });
+
+  itIfBuilt('--auto applies safe fixes when claude-recall is on PATH', () => {
+    const tmpHome = mkTmp();
+    const shimDir = mkTmp('repair-shim-');
+    try {
+      const claudeDir = path.join(tmpHome, '.claude');
+      fs.mkdirSync(claudeDir);
+      const settingsPath = path.join(claudeDir, 'settings.json');
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooksVersion: '6.0.0',
+        hooks: {
+          Stop: [{
+            hooks: [
+              { type: 'command', command: 'python3 /tmp/some-other-hook.py' },
+              {
+                type: 'command',
+                command: 'node /gone/claude-recall-cli.js hook run memory-stop',
+                timeout: 30,
+              },
+            ],
+          }],
+        },
+      }));
+
+      // Fake `claude-recall` on PATH via a tiny shim in shimDir.
+      const shimPath = path.join(shimDir, 'claude-recall');
+      fs.writeFileSync(shimPath, '#!/bin/sh\nexit 0\n');
+      fs.chmodSync(shimPath, 0o755);
+
+      const res = runCli(['repair', '--auto', '--scope', 'user'], {
+        env: {
+          ...process.env,
+          HOME: tmpHome,
+          PATH: `${shimDir}${path.delimiter}${process.env.PATH || ''}`,
+        },
+      });
+      expect(res.status).toBe(0);
+
+      const after = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      const group = after.hooks.Stop[0];
+      // sibling python hook untouched
+      expect(group.hooks[0].command).toBe('python3 /tmp/some-other-hook.py');
+      // broken absolute rewritten to PATH form, timeout preserved
+      expect(group.hooks[1].command).toBe('claude-recall hook run memory-stop');
+      expect(group.hooks[1].timeout).toBe(30);
+      // hooksVersion untouched
+      expect(after.hooksVersion).toBe('6.0.0');
+      // backup written
+      expect(fs.readdirSync(claudeDir).some(n => n.startsWith('settings.json.bak')))
+        .toBe(true);
+    } finally {
+      rmTmp(tmpHome);
+      rmTmp(shimDir);
+    }
+  });
+
+  itIfBuilt('--auto exits 0 and reports when claude-recall is not on PATH', () => {
+    const tmpHome = mkTmp();
+    try {
+      const claudeDir = path.join(tmpHome, '.claude');
+      fs.mkdirSync(claudeDir);
+      const settingsPath = path.join(claudeDir, 'settings.json');
+      const original = {
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: 'node /gone/claude-recall-cli.js hook run memory-stop' }] }],
+        },
+      };
+      fs.writeFileSync(settingsPath, JSON.stringify(original));
+
+      // Scrub PATH so claude-recall is not resolvable.
+      const res = runCli(['repair', '--auto', '--scope', 'user'], {
+        env: { ...process.env, HOME: tmpHome, PATH: '/nonexistent' },
+      });
+      expect(res.status).toBe(0);
+      expect(res.stdout + res.stderr).toMatch(/npm install -g claude-recall|no safe fix/i);
+
+      const after = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      expect(after).toEqual(original);
+    } finally {
+      rmTmp(tmpHome);
+    }
+  });
+
+  itIfBuilt('no-op when no settings files exist under the home', () => {
+    const tmpHome = mkTmp();
+    try {
+      const res = runCli(['repair', '--auto', '--scope', 'user'], {
+        env: { ...process.env, HOME: tmpHome },
+      });
+      expect(res.status).toBe(0);
+      expect(res.stdout + res.stderr).toMatch(/No settings files found/);
+      expect(fs.existsSync(path.join(tmpHome, '.claude'))).toBe(false);
+    } finally {
+      rmTmp(tmpHome);
+    }
+  });
+
+  itIfBuilt('rejects unknown --scope values', () => {
+    const res = runCli(['repair', '--scope', 'bogus', '--auto']);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/Invalid --scope/);
+  });
+});

--- a/tests/unit/repair.test.ts
+++ b/tests/unit/repair.test.ts
@@ -1,0 +1,413 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  classifyHook,
+  findSettingsFiles,
+  scanFile,
+  applyFixes,
+  runRepair,
+} from '../../src/cli/commands/repair';
+
+function mkTmp(prefix = 'repair-test-'): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function rmTmp(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+const resolverYes = () => '/usr/bin/claude-recall';
+const resolverNo = () => null;
+
+describe('classifyHook', () => {
+  it('classifies non-claude-recall commands as non-claude-recall', () => {
+    expect(classifyHook('python3 /home/u/.claude/hooks/enforcer.py', resolverYes))
+      .toEqual({ status: 'non-claude-recall' });
+    expect(classifyHook('echo hello', resolverYes))
+      .toEqual({ status: 'non-claude-recall' });
+    expect(classifyHook('', resolverYes))
+      .toEqual({ status: 'non-claude-recall' });
+  });
+
+  it('classifies an OK node+absolute-path claude-recall hook', () => {
+    const tmp = mkTmp();
+    const scriptPath = path.join(tmp, 'claude-recall-cli.js');
+    fs.writeFileSync(scriptPath, '// stub');
+    try {
+      const cmd = `node ${scriptPath} hook run memory-stop`;
+      expect(classifyHook(cmd, resolverYes)).toEqual({ status: 'ok' });
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+
+  it('classifies a missing absolute script as broken-absolute with hookId extracted', () => {
+    const cmd = 'node /home/openclaw/node_modules/claude-recall/dist/cli/claude-recall-cli.js hook run memory-stop';
+    const result = classifyHook(cmd, resolverYes);
+    expect(result).toEqual({
+      status: 'broken-absolute',
+      scriptPath: '/home/openclaw/node_modules/claude-recall/dist/cli/claude-recall-cli.js',
+      hookId: 'memory-stop',
+    });
+  });
+
+  it('classifies a missing absolute script with no hook-run subcommand (hookId null)', () => {
+    const cmd = 'node /home/nope/claude-recall-cli.js something-else';
+    const result = classifyHook(cmd, resolverYes);
+    expect(result).toMatchObject({ status: 'broken-absolute', hookId: null });
+  });
+
+  it('classifies `claude-recall hook run ...` as OK when on PATH', () => {
+    expect(classifyHook('claude-recall hook run memory-stop', resolverYes))
+      .toEqual({ status: 'ok' });
+  });
+
+  it('classifies `claude-recall hook run ...` as broken-path when not on PATH', () => {
+    const result = classifyHook('claude-recall hook run memory-stop', resolverNo);
+    expect(result).toEqual({
+      status: 'broken-path',
+      binary: 'claude-recall',
+      hookId: 'memory-stop',
+    });
+  });
+
+  it('treats `npx claude-recall ...` as OK (resolved at runtime)', () => {
+    expect(classifyHook('npx claude-recall hook run memory-stop', resolverNo))
+      .toEqual({ status: 'ok' });
+  });
+});
+
+describe('findSettingsFiles', () => {
+  it('returns only files that exist (user scope)', () => {
+    const tmp = mkTmp();
+    try {
+      const userClaude = path.join(tmp, '.claude');
+      fs.mkdirSync(userClaude, { recursive: true });
+      fs.writeFileSync(path.join(userClaude, 'settings.json'), '{}');
+      const results = findSettingsFiles('/irrelevant', tmp, 'user');
+      expect(results).toEqual([path.join(userClaude, 'settings.json')]);
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+
+  it('walks up for project scope and stops at closest .claude', () => {
+    const tmp = mkTmp();
+    try {
+      const projRoot = path.join(tmp, 'proj');
+      const deep = path.join(projRoot, 'a', 'b', 'c');
+      fs.mkdirSync(deep, { recursive: true });
+      const claudeDir = path.join(projRoot, '.claude');
+      fs.mkdirSync(claudeDir);
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), '{}');
+      fs.writeFileSync(path.join(claudeDir, 'settings.local.json'), '{}');
+
+      const results = findSettingsFiles(deep, os.homedir(), 'project');
+      expect(results).toContain(path.join(claudeDir, 'settings.json'));
+      expect(results).toContain(path.join(claudeDir, 'settings.local.json'));
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+
+  it('returns [] when no settings files exist anywhere', () => {
+    const tmp = mkTmp();
+    try {
+      const results = findSettingsFiles(tmp, tmp, 'all');
+      expect(results).toEqual([]);
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+});
+
+describe('scanFile', () => {
+  it('records parseError for invalid JSON (does not throw)', () => {
+    const tmp = mkTmp();
+    try {
+      const p = path.join(tmp, 'settings.json');
+      fs.writeFileSync(p, '{ not valid json');
+      const report = scanFile(p, resolverYes);
+      expect(report.parseError).toMatch(/invalid JSON/);
+      expect(report.findings).toEqual([]);
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+
+  it('finds broken-absolute and proposes PATH-resolved fix when claude-recall available', () => {
+    const tmp = mkTmp();
+    try {
+      const p = path.join(tmp, 'settings.json');
+      const settings = {
+        hooksVersion: '6.0.0',
+        hooks: {
+          Stop: [
+            {
+              hooks: [
+                {
+                  type: 'command',
+                  command: 'node /home/openclaw/node_modules/claude-recall/dist/cli/claude-recall-cli.js hook run memory-stop',
+                  timeout: 30,
+                },
+              ],
+            },
+          ],
+        },
+      };
+      fs.writeFileSync(p, JSON.stringify(settings));
+
+      const report = scanFile(p, resolverYes);
+      expect(report.hooksVersion).toBe('6.0.0');
+      expect(report.findings).toHaveLength(1);
+      const f = report.findings[0];
+      expect(f.classification.status).toBe('broken-absolute');
+      expect(f.proposedCommand).toBe('claude-recall hook run memory-stop');
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+
+  it('leaves no proposedCommand when claude-recall is NOT on PATH', () => {
+    const tmp = mkTmp();
+    try {
+      const p = path.join(tmp, 'settings.json');
+      fs.writeFileSync(p, JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: 'node /missing/claude-recall-cli.js hook run memory-stop' }] }],
+        },
+      }));
+      const report = scanFile(p, resolverNo);
+      expect(report.findings[0].classification.status).toBe('broken-absolute');
+      expect(report.findings[0].proposedCommand).toBeUndefined();
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+
+  it('ignores non-claude-recall hooks (e.g. python3 search_enforcer.py)', () => {
+    const tmp = mkTmp();
+    try {
+      const p = path.join(tmp, 'settings.json');
+      fs.writeFileSync(p, JSON.stringify({
+        hooks: {
+          PreToolUse: [{
+            matcher: '.*',
+            hooks: [{ type: 'command', command: 'python3 /home/u/.claude/hooks/search_enforcer.py' }],
+          }],
+        },
+      }));
+      const report = scanFile(p, resolverYes);
+      expect(report.findings).toEqual([]);
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+});
+
+describe('applyFixes', () => {
+  it('rewrites only broken-absolute; preserves timeout, matcher, and sibling hooks', () => {
+    const tmp = mkTmp();
+    try {
+      const p = path.join(tmp, 'settings.json');
+      const siblingCmd = 'python3 /home/u/.claude/hooks/search_enforcer.py';
+      const settings = {
+        hooksVersion: '6.0.0',
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: '.*',
+              hooks: [
+                { type: 'command', command: siblingCmd },
+                {
+                  type: 'command',
+                  command: 'node /home/openclaw/node_modules/claude-recall/dist/cli/claude-recall-cli.js hook run rule-injector',
+                  timeout: 5,
+                },
+              ],
+            },
+          ],
+        },
+      };
+      fs.writeFileSync(p, JSON.stringify(settings));
+
+      const report = scanFile(p, resolverYes);
+      const { changed, applied, backupPath } = applyFixes(report, { dryRun: false });
+      expect(changed).toBe(true);
+      expect(applied).toBe(1);
+      expect(backupPath).toBeTruthy();
+      expect(fs.existsSync(backupPath!)).toBe(true);
+
+      const written = JSON.parse(fs.readFileSync(p, 'utf8'));
+      expect(written.hooksVersion).toBe('6.0.0'); // untouched
+      const group = written.hooks.PreToolUse[0];
+      expect(group.matcher).toBe('.*');
+      expect(group.hooks[0].command).toBe(siblingCmd); // sibling preserved
+      expect(group.hooks[1].command).toBe('claude-recall hook run rule-injector');
+      expect(group.hooks[1].timeout).toBe(5); // timeout preserved
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+
+  it('dry-run writes nothing and returns no backup path', () => {
+    const tmp = mkTmp();
+    try {
+      const p = path.join(tmp, 'settings.json');
+      const original = {
+        hooks: {
+          Stop: [{
+            hooks: [{
+              type: 'command',
+              command: 'node /missing/claude-recall-cli.js hook run memory-stop',
+              timeout: 30,
+            }],
+          }],
+        },
+      };
+      fs.writeFileSync(p, JSON.stringify(original));
+
+      const report = scanFile(p, resolverYes);
+      const { changed, applied, backupPath } = applyFixes(report, { dryRun: true });
+      expect(changed).toBe(true);
+      expect(applied).toBe(1);
+      expect(backupPath).toBeNull();
+
+      const afterDryRun = JSON.parse(fs.readFileSync(p, 'utf8'));
+      expect(afterDryRun).toEqual(original);
+      // no backup files
+      expect(fs.readdirSync(tmp).filter(n => n.startsWith('settings.json.bak')))
+        .toEqual([]);
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+});
+
+describe('runRepair', () => {
+  function makeLogger() {
+    const messages: string[] = [];
+    return {
+      messages,
+      logger: {
+        log: (m: string) => messages.push(m),
+        warn: (m: string) => messages.push(m),
+      },
+    };
+  }
+
+  it('no-op when no settings files exist', async () => {
+    const tmp = mkTmp();
+    try {
+      const { logger, messages } = makeLogger();
+      const result = await runRepair({
+        auto: true, scope: 'all', cwd: tmp, home: tmp, logger,
+        claudeRecallOnPath: resolverYes,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.filesScanned).toBe(0);
+      expect(result.filesModified).toBe(0);
+      expect(messages.join('\n')).toMatch(/No settings files found/);
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+
+  it('applies safe fixes in --auto mode without prompting', async () => {
+    const tmp = mkTmp();
+    try {
+      const claudeDir = path.join(tmp, '.claude');
+      fs.mkdirSync(claudeDir);
+      const settingsPath = path.join(claudeDir, 'settings.json');
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooksVersion: '6.0.0',
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: 'node /gone/claude-recall-cli.js hook run memory-stop', timeout: 30 }] }],
+        },
+      }));
+
+      const { logger } = makeLogger();
+      const result = await runRepair({
+        auto: true, scope: 'user', home: tmp, cwd: '/not-used', logger,
+        claudeRecallOnPath: resolverYes,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.filesModified).toBe(1);
+      expect(result.fixesApplied).toBe(1);
+
+      const written = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      expect(written.hooks.Stop[0].hooks[0].command).toBe('claude-recall hook run memory-stop');
+      expect(written.hooks.Stop[0].hooks[0].timeout).toBe(30);
+      expect(written.hooksVersion).toBe('6.0.0'); // conservative: unchanged
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+
+  it('reports unfixable issues without exiting non-zero (postinstall safety)', async () => {
+    const tmp = mkTmp();
+    try {
+      const claudeDir = path.join(tmp, '.claude');
+      fs.mkdirSync(claudeDir);
+      const settingsPath = path.join(claudeDir, 'settings.json');
+      fs.writeFileSync(settingsPath, JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: 'node /gone/claude-recall-cli.js hook run memory-stop' }] }],
+        },
+      }));
+
+      const { logger, messages } = makeLogger();
+      const result = await runRepair({
+        auto: true, scope: 'user', home: tmp, logger,
+        claudeRecallOnPath: resolverNo, // no binary on PATH → can't fix
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.filesModified).toBe(0);
+      expect(result.unfixable).toBe(1);
+      expect(messages.join('\n')).toMatch(/npm install -g claude-recall/);
+
+      // File unchanged
+      const afterRun = fs.readFileSync(settingsPath, 'utf8');
+      expect(afterRun).toMatch('hook run memory-stop');
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+
+  it('does not create hooks where none exist', async () => {
+    const tmp = mkTmp();
+    try {
+      // No .claude directory at all
+      const { logger } = makeLogger();
+      const result = await runRepair({
+        auto: true, scope: 'all', home: tmp, cwd: tmp, logger,
+        claudeRecallOnPath: resolverYes,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.filesScanned).toBe(0);
+      expect(fs.existsSync(path.join(tmp, '.claude'))).toBe(false);
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+
+  it('handles malformed settings.json gracefully and exits 0', async () => {
+    const tmp = mkTmp();
+    try {
+      const claudeDir = path.join(tmp, '.claude');
+      fs.mkdirSync(claudeDir);
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), '{ invalid');
+
+      const { logger, messages } = makeLogger();
+      const result = await runRepair({
+        auto: true, scope: 'user', home: tmp, logger,
+        claudeRecallOnPath: resolverYes,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(messages.join('\n')).toMatch(/invalid JSON/);
+    } finally {
+      rmTmp(tmp);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Reworks `claude-recall repair` from an opinionated template-rewriter into a **conservative** scanner that only fixes broken absolute paths in claude-recall hook commands — preserving timeouts, matchers, sibling hooks, `hooksVersion`, and all unrelated settings.
- Adds `--auto`, `--dry-run`, `--scope user|project|all`, and `--reinstall-hooks` flags. Legacy `--force` kept as an alias for `--reinstall-hooks` for backwards compatibility.
- `scripts/postinstall.js` now runs `claude-recall repair --auto --scope user` on upgrade, self-healing the common "old claude-recall install path no longer exists" failure — without clobbering user customizations or installing hooks where none exist (respects the 0.24.0 postinstall hardening rule).

### Motivation

On a user's remote VM, `~/.claude/settings.json` pointed at `/home/USER/node_modules/claude-recall/dist/cli/claude-recall-cli.js` — a path that no longer existed after the install moved. Every `Stop` / `UserPromptSubmit` / `PreCompact` hook threw `MODULE_NOT_FOUND: Cannot find module ...`. The same class of breakage happens anywhere node/nvm versions or install paths drift between the time hooks were written and today. `claude-recall repair --auto` now fixes it in place, and postinstall runs it for you on upgrade.

### Conservative guarantees (tested)

- Only rewrites claude-recall hook commands whose absolute script path is missing on disk.
- Rewrites to the PATH-resolved form `claude-recall hook run <id>` — only if `claude-recall` is on PATH; otherwise reports the issue and exits 0 with install instructions.
- Preserves hook `timeout`, group `matcher`, and every sibling hook (including non-claude-recall hooks like `python3 search_enforcer.py`).
- Does not touch `hooksVersion`.
- Does not install hooks where none exist.
- Writes `<path>.bak.<iso-timestamp>` before any mutation.
- Postinstall failure is non-fatal — `npm install` always succeeds.

## Test plan

- [x] 21 new unit tests in `tests/unit/repair.test.ts` (classification, rewrite preservation, backup, dry-run, PATH resolution, malformed JSON, no-hooks no-op).
- [x] 5 new integration tests in `tests/integration/repair-cli.test.ts` spawning the compiled CLI.
- [x] Full suite: 499/499 passing.
- [x] End-to-end smoke test against a fixture replicating the originating VM failure (stale `/home/openclaw/...` paths, `hooksVersion: "6.0.0"`, sibling python3 hook) — all guarantees verified.
- [ ] CI `Lint would-be npm tarball` check expected to pass (no file surface changes beyond `src/`, `tests/`, `scripts/postinstall.js`, and docs).

## Files

- `src/cli/commands/repair.ts` (new) — pure scanner + rewriter.
- `src/cli/claude-recall-cli.ts` — CLI wiring for new flags.
- `scripts/postinstall.js` — non-fatal `repair --auto --scope user` on upgrade.
- `tests/unit/repair.test.ts` (new), `tests/integration/repair-cli.test.ts` (new).
- `README.md`, `CHANGELOG.md` — updated.
- `package.json` — version bump 0.24.2 → 0.25.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)