### PR TITLE
fix(repair): --scope all walks entire home for project settings (0.25.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.1] - 2026-04-28
+
+### Fixed
+
+- **`claude-recall repair --scope all` now walks the entire user home for project-level `.claude/settings.json` files**, not just the closest one to cwd. The 0.25.0 postinstall ran `repair --auto --scope user` and only healed `~/.claude/settings.json`; per-project hooks under `~/projects/...` were silently left broken when an install moved (e.g. removing a duplicate global at `~/.nvm/versions/node/vXX/lib/node_modules/claude-recall/` would break every project whose `.claude/settings.json` hardcoded that absolute path). 0.25.1 changes:
+  - New exported `findHomeProjectSettings(home)` walks `$HOME` with a prune list (`node_modules`, `.git`, `.npm`, `.nvm`, `.cache`, `.pnpm-store`, `.yarn`, `dist`, `build`, etc.), depth-limited to 8, and never follows symlinks.
+  - `--scope all` semantics widened to "user-global + every project under `$HOME`". The cwd-walk-closest-project behavior remains under `--scope project`.
+  - `scripts/postinstall.js` now invokes `repair --auto --scope all` (timeout raised to 60s for the home walk). Still non-fatal — `npm install` always succeeds.
+  - 7 new unit tests covering nested project discovery, prune behavior, symlink loop avoidance, unreadable-directory tolerance, and home-walk vs. cwd-walk separation.
+
 ## [0.25.0] - 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ claude-recall status                     # Installation and system status
 claude-recall repair                     # Fix broken claude-recall hook paths (conservative: preserves user customizations)
 claude-recall repair --auto              # Non-interactive; apply safe fixes without prompting (used by postinstall)
 claude-recall repair --dry-run           # Report what would change without writing
-claude-recall repair --scope user|project|all  # Scope the scan (default: all)
+claude-recall repair --scope user|project|all  # Scope the scan: user (~/.claude), project (closest .claude walking up from cwd), all (user + every nested project under ~). Default: all
 claude-recall repair --reinstall-hooks   # Opinionated: rewrite entire hook block from current template
 claude-recall hooks check                # Verify hook files exist and are valid
 claude-recall hooks test-enforcement     # Test if search enforcer hook works

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-recall",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Persistent memory for Claude Code and Pi with native Skills integration, automatic capture, failure learning, and project scoping",
   "main": "dist/index.js",
   "bin": {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -118,21 +118,24 @@ try {
   // produces a diff the user can see.
 
   // Conservative repair on upgrade: fix broken absolute hook paths in
-  // ~/.claude/settings.json that reference a defunct claude-recall install
-  // (common when node/nvm versions change, or when the package was reinstalled
-  // into a different location). The --auto --scope user flags mean:
-  //   • only user-global settings are touched (no project files)
+  // ~/.claude/settings.json AND every project's .claude/settings.json under
+  // the user's home. Common when node/nvm versions change, or when the package
+  // was reinstalled into a different location (e.g. moving from a root-owned
+  // global prefix to ~/.npm-global). The --auto --scope all flags mean:
+  //   • user-global settings AND every nested project settings file are scanned
   //   • only commands pointing at MISSING absolute scripts get rewritten
   //   • user customizations (timeouts, matchers, sibling hooks) preserved
   //   • writes a .bak.<timestamp> before any change
   //   • never installs hooks where none exist — satisfies the "don't clobber"
   //     rule above
+  // Timeout raised because the home walk can touch many directories on
+  // larger machines.
   try {
     const cliPath = path.join(__dirname, '..', 'dist', 'cli', 'claude-recall-cli.js');
     if (fs.existsSync(cliPath)) {
-      execSync(`node "${cliPath}" repair --auto --scope user`, {
+      execSync(`node "${cliPath}" repair --auto --scope all`, {
         stdio: 'inherit',
-        timeout: 15000
+        timeout: 60000
       });
     }
   } catch (repairError) {

--- a/src/cli/commands/repair.ts
+++ b/src/cli/commands/repair.ts
@@ -166,6 +166,93 @@ function pickSiblings(settingsPath: string): string[] {
   return out;
 }
 
+// Directory names that are guaranteed not to contain a project's `.claude/`
+// dir but tend to be huge. Pruning them keeps the home walk fast even on
+// machines with sprawling node_modules/cache trees.
+const HOME_WALK_PRUNE = new Set<string>([
+  'node_modules',
+  '.git',
+  '.npm',
+  '.nvm',
+  '.cache',
+  '.pnpm-store',
+  '.yarn',
+  '.docker',
+  '.local',
+  '.cargo',
+  '.rustup',
+  '.gradle',
+  '.m2',
+  '.vscode-server',
+  '.cursor-server',
+  'Library',
+  'AppData',
+  'dist',
+  'build',
+  'target',
+  '__pycache__',
+  '.venv',
+  'venv',
+  '.tox',
+  '.mypy_cache',
+  '.pytest_cache',
+  '.next',
+  '.turbo',
+]);
+
+const HOME_WALK_MAX_DEPTH = 8;
+
+/**
+ * Walk $HOME (excluding the user-global ~/.claude/ itself) for every nested
+ * `.claude/settings.json` and `.claude/settings.local.json`. Conservative on
+ * descent — never follows symlinks, prunes well-known bloat dirs, depth-limited.
+ * Used by --scope all to find every project under home that may have stale
+ * claude-recall hook paths after an install moves.
+ */
+export function findHomeProjectSettings(home: string): string[] {
+  const results: string[] = [];
+  const userClaudeDir = path.join(home, '.claude');
+
+  function walk(dir: string, depth: number): void {
+    if (depth > HOME_WALK_MAX_DEPTH) return;
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return; // permission denied, gone, etc. — silently skip
+    }
+
+    for (const entry of entries) {
+      // Don't follow symlinks (loop avoidance, also unlikely to host the
+      // canonical project root we want to scan).
+      if (entry.isSymbolicLink()) continue;
+
+      if (entry.isDirectory()) {
+        if (HOME_WALK_PRUNE.has(entry.name)) continue;
+
+        const child = path.join(dir, entry.name);
+
+        if (entry.name === '.claude') {
+          // Skip the user-global ~/.claude/ — that's covered by --scope user.
+          if (child === userClaudeDir) continue;
+
+          for (const f of pickSiblings(path.join(child, 'settings.json'))) {
+            if (!results.includes(f)) results.push(f);
+          }
+          // Don't descend into .claude/ — settings files live at its root.
+          continue;
+        }
+
+        walk(child, depth + 1);
+      }
+    }
+  }
+
+  walk(home, 0);
+  return results;
+}
+
 export function findSettingsFiles(
   cwd: string,
   home: string,
@@ -180,10 +267,17 @@ export function findSettingsFiles(
     }
   }
 
-  if (scope === 'project' || scope === 'all') {
-    // Walk up looking for the CLOSEST .claude dir containing a settings file
-    // (matches Claude Code's own resolution). We don't scan ancestors beyond
-    // the first match — those belong to other projects.
+  if (scope === 'all') {
+    // For --scope all we walk the entire home tree to catch every project's
+    // .claude/settings.json — important for postinstall, where stale hook paths
+    // in ANY project on the machine break Claude Code in that project.
+    for (const p of findHomeProjectSettings(home)) {
+      if (!results.includes(p)) results.push(p);
+    }
+  } else if (scope === 'project') {
+    // For --scope project we only walk up from cwd looking for the CLOSEST
+    // .claude dir (matches Claude Code's own resolution). We don't scan
+    // ancestors beyond the first match — those belong to other projects.
     let dir = cwd;
     while (dir !== path.dirname(dir)) {
       const claudeDir = path.join(dir, '.claude');

--- a/tests/unit/repair.test.ts
+++ b/tests/unit/repair.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import {
   classifyHook,
   findSettingsFiles,
+  findHomeProjectSettings,
   scanFile,
   applyFixes,
   runRepair,
@@ -118,6 +119,147 @@ describe('findSettingsFiles', () => {
       expect(results).toEqual([]);
     } finally {
       rmTmp(tmp);
+    }
+  });
+
+  it('--scope all walks the entire home tree (not just cwd-closest project)', () => {
+    const home = mkTmp('repair-home-');
+    try {
+      // Create three projects under home, none of them ancestors of each other,
+      // and none reachable by walking up from the home root.
+      const projA = path.join(home, 'projects', 'alpha');
+      const projB = path.join(home, 'projects', 'beta');
+      const projC = path.join(home, 'work', 'nested', 'gamma');
+      for (const p of [projA, projB, projC]) {
+        const claudeDir = path.join(p, '.claude');
+        fs.mkdirSync(claudeDir, { recursive: true });
+        fs.writeFileSync(path.join(claudeDir, 'settings.json'), '{}');
+      }
+
+      const results = findSettingsFiles('/some/unrelated/cwd', home, 'all');
+      expect(results).toEqual(expect.arrayContaining([
+        path.join(projA, '.claude', 'settings.json'),
+        path.join(projB, '.claude', 'settings.json'),
+        path.join(projC, '.claude', 'settings.json'),
+      ]));
+    } finally {
+      rmTmp(home);
+    }
+  });
+});
+
+describe('findHomeProjectSettings', () => {
+  it('finds nested .claude/settings.json under home', () => {
+    const home = mkTmp('hps-');
+    try {
+      const proj = path.join(home, 'work', 'cool-app');
+      const claudeDir = path.join(proj, '.claude');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.writeFileSync(path.join(claudeDir, 'settings.json'), '{}');
+      fs.writeFileSync(path.join(claudeDir, 'settings.local.json'), '{}');
+      const results = findHomeProjectSettings(home);
+      expect(results).toContain(path.join(claudeDir, 'settings.json'));
+      expect(results).toContain(path.join(claudeDir, 'settings.local.json'));
+    } finally {
+      rmTmp(home);
+    }
+  });
+
+  it('skips the user-global ~/.claude/ itself (caller covers it via --scope user)', () => {
+    const home = mkTmp('hps-user-');
+    try {
+      const userClaude = path.join(home, '.claude');
+      fs.mkdirSync(userClaude);
+      fs.writeFileSync(path.join(userClaude, 'settings.json'), '{}');
+      const results = findHomeProjectSettings(home);
+      expect(results).not.toContain(path.join(userClaude, 'settings.json'));
+    } finally {
+      rmTmp(home);
+    }
+  });
+
+  it('prunes node_modules and other bloat dirs', () => {
+    const home = mkTmp('hps-prune-');
+    try {
+      // A real project (should be found):
+      const realProj = path.join(home, 'work', 'real');
+      fs.mkdirSync(path.join(realProj, '.claude'), { recursive: true });
+      fs.writeFileSync(path.join(realProj, '.claude', 'settings.json'), '{}');
+
+      // A .claude/ inside node_modules (should be pruned):
+      const inNodeModules = path.join(home, 'work', 'real', 'node_modules', 'fake-pkg');
+      fs.mkdirSync(path.join(inNodeModules, '.claude'), { recursive: true });
+      fs.writeFileSync(path.join(inNodeModules, '.claude', 'settings.json'), '{}');
+
+      // A .claude/ inside .git (should be pruned):
+      const inGit = path.join(home, 'work', 'real', '.git', 'somewhere');
+      fs.mkdirSync(path.join(inGit, '.claude'), { recursive: true });
+      fs.writeFileSync(path.join(inGit, '.claude', 'settings.json'), '{}');
+
+      const results = findHomeProjectSettings(home);
+      expect(results).toContain(path.join(realProj, '.claude', 'settings.json'));
+      expect(results).not.toContain(path.join(inNodeModules, '.claude', 'settings.json'));
+      expect(results).not.toContain(path.join(inGit, '.claude', 'settings.json'));
+    } finally {
+      rmTmp(home);
+    }
+  });
+
+  it('does not follow symlinks (loop avoidance)', () => {
+    const home = mkTmp('hps-sym-');
+    try {
+      // Real project at home/work/real
+      const realProj = path.join(home, 'work', 'real');
+      fs.mkdirSync(path.join(realProj, '.claude'), { recursive: true });
+      fs.writeFileSync(path.join(realProj, '.claude', 'settings.json'), '{}');
+
+      // Symlink at home/loop pointing back to home — would infinite-loop
+      // a naive walker.
+      try {
+        fs.symlinkSync(home, path.join(home, 'loop'));
+      } catch {
+        // some environments (e.g. some CI runners) disallow symlinks; skip cleanly
+        return;
+      }
+
+      const results = findHomeProjectSettings(home);
+      // Should still return the real project, and should not loop forever.
+      expect(results).toContain(path.join(realProj, '.claude', 'settings.json'));
+    } finally {
+      rmTmp(home);
+    }
+  });
+
+  it('returns [] when home has no projects', () => {
+    const home = mkTmp('hps-empty-');
+    try {
+      expect(findHomeProjectSettings(home)).toEqual([]);
+    } finally {
+      rmTmp(home);
+    }
+  });
+
+  it('survives unreadable directories without throwing', () => {
+    const home = mkTmp('hps-perm-');
+    try {
+      // Create a real project that should still be found
+      const realProj = path.join(home, 'work', 'real');
+      fs.mkdirSync(path.join(realProj, '.claude'), { recursive: true });
+      fs.writeFileSync(path.join(realProj, '.claude', 'settings.json'), '{}');
+
+      // A directory we can't read
+      const blocked = path.join(home, 'blocked');
+      fs.mkdirSync(blocked);
+      try {
+        fs.chmodSync(blocked, 0o000);
+        const results = findHomeProjectSettings(home);
+        expect(results).toContain(path.join(realProj, '.claude', 'settings.json'));
+      } finally {
+        // restore so cleanup works
+        fs.chmodSync(blocked, 0o755);
+      }
+    } finally {
+      rmTmp(home);
     }
   });
 });


### PR DESCRIPTION
## Summary

The 0.25.0 postinstall ran `repair --auto --scope user` and only healed `~/.claude/settings.json`. **Per-project `.claude/settings.json` files under `$HOME` were silently left broken** when an install moved — exactly the failure surfaced after the 0.25.0 ship: removing a duplicate global at `~/.nvm/.../node_modules/claude-recall/` broke 3 projects whose hooks hardcoded that absolute path, requiring manual `cd <each-project> && claude-recall repair --auto --scope project` to fix.

This PR closes that gap.

### Changes

- **New exported `findHomeProjectSettings(home)`** — depth-limited walker (max 8) that returns every nested `.claude/settings(.local).json` under `$HOME`, with aggressive prune list (`node_modules`, `.git`, `.npm`, `.nvm`, `.cache`, `.pnpm-store`, `.yarn`, `dist`, `build`, `target`, etc.) and no symlink follow (loop avoidance). Skips `~/.claude/` itself — that's covered by `--scope user`.
- **`--scope all` semantics widened** to "user-global + every project under `$HOME`". The cwd-walk-closest-project behavior remains under `--scope project`.
- **`scripts/postinstall.js` switches to `repair --auto --scope all`**; timeout raised to 60s for the home walk. Still non-fatal — `npm install` always succeeds.

### Conservative guarantees retained

Every guarantee from 0.25.0 still holds — only rewrites broken absolute claude-recall paths, preserves timeouts/matchers/sibling hooks, never bumps `hooksVersion`, never installs hooks where none exist, writes a `.bak.<timestamp>` per file. The change is purely about *which files* get scanned.

## Test plan

- [x] 7 new unit tests in `tests/unit/repair.test.ts`:
  - `findHomeProjectSettings` finds nested `.claude/settings.json` files
  - skips the user-global `~/.claude/` itself
  - prunes `node_modules` and `.git` (creates fixture `.claude/` inside both)
  - does not follow symlinks (creates a self-symlink that would loop a naive walker)
  - returns `[]` for empty home
  - survives unreadable directories without throwing (creates a chmod-000 dir)
  - end-to-end: `findSettingsFiles(cwd, home, 'all')` picks up three nested projects from a cwd outside any of them
- [x] Full suite: 506/506 passing.
- [x] Validated in production on the originating VM: cleaning a duplicate global broke 3 projects' hooks; `claude-recall repair --auto --scope project` per project healed all 38 broken hook entries (10+14+14) with backups. With this PR, postinstall does that in one shot for the next user.

## Files

- `src/cli/commands/repair.ts` — `findHomeProjectSettings` + scope semantics
- `scripts/postinstall.js` — `--scope all` + 60s timeout
- `tests/unit/repair.test.ts` — 7 new tests
- `README.md` — clarified `--scope` description
- `CHANGELOG.md` — 0.25.1 entry
- `package.json` — 0.25.0 → 0.25.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)